### PR TITLE
update_trips_data script to add incremental new data

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,14 @@ Note: the raw data is a single uncompressed ~40GB .csv file, it will take a litt
 ./import_trip_data.sh
 ```
 
+New data is available monthly. Once you've run the full setup, in future you can download and process only the latest data by running
+
+```
+./update_trips_data.sh
+```
+
+This has the advantage of not downloading the entire 40 GB dataset every time you want to update a new month
+
 ##### 3. Analysis
 
 `prepare_analysis.sql` and `analysis.R` scripts to do analysis in Postgres and [R](https://www.r-project.org/)

--- a/create_schema.sql
+++ b/create_schema.sql
@@ -2,9 +2,9 @@ CREATE EXTENSION postgis;
 
 CREATE TABLE trips_raw (
   trip_id varchar primary key,
-  external_taxi_id varchar,
-  trip_start timestamp without time zone,
-  trip_end timestamp without time zone,
+  taxi_id varchar,
+  trip_start_timestamp timestamp without time zone,
+  trip_end_timestamp timestamp without time zone,
   trip_seconds numeric,
   trip_miles numeric,
   pickup_census_tract varchar,

--- a/import_trip_data.sh
+++ b/import_trip_data.sh
@@ -1,7 +1,8 @@
 #!/bin/bash
 
 echo "`date`: beginning raw data load"
-cat data/taxi_trips.csv | psql chicago-taxi-data -c "COPY trips_raw FROM stdin CSV HEADER;"
+schema=`head -n 1 data/taxi_trips.csv`
+cat data/taxi_trips.csv | psql chicago-taxi-data -c "COPY trips_raw (${schema}) FROM stdin CSV HEADER;"
 
 echo "`date`: finished raw data load; populating trips data"
 psql chicago-taxi-data -f populate_trips.sql

--- a/populate_trips.sql
+++ b/populate_trips.sql
@@ -1,14 +1,14 @@
 INSERT INTO taxis (external_id)
-SELECT DISTINCT external_taxi_id
+SELECT DISTINCT taxi_id
 FROM trips_raw
-WHERE external_taxi_id NOT IN (SELECT external_id FROM taxis);
+WHERE taxi_id NOT IN (SELECT external_id FROM taxis);
 
 INSERT INTO trips
 SELECT
   trip_id,
   taxis.id,
-  trip_start,
-  trip_end,
+  trip_start_timestamp,
+  trip_end_timestamp,
   trip_seconds,
   trip_miles,
   pickup_census_tract,
@@ -28,6 +28,7 @@ SELECT
   dropoff_centroid_longitude,
   community_areas
 FROM trips_raw t, taxis
-WHERE t.external_taxi_id = taxis.external_id;
+WHERE t.taxi_id = taxis.external_id
+ON CONFLICT DO NOTHING;
 
 TRUNCATE TABLE trips_raw;

--- a/update_trips_data.sh
+++ b/update_trips_data.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+
+ts=$(psql -P t -P format=unaligned -d chicago-taxi-data -c "SELECT date(max(trip_start) - '2 days'::interval) FROM trips")
+url="https://data.cityofchicago.org/resource/wrvz-psew.csv?%24where=trip_start_timestamp%20>=%20'${ts}'&%24limit=1000000000"
+
+echo "downloading data from ${url}"
+wget -O data/taxi_trips.csv ${url}
+
+./import_trip_data.sh


### PR DESCRIPTION
Add a new script `update_trips_data.sh` that

1. checks the `trips` table for the most recent data available
2. downloads all trip data after that (with a 2-day overlap)
3. inserts new records into the `trips` table

This makes it possible to update the data without downloading the full 40 GB file every time